### PR TITLE
MTDSA-30046 Set uniqueness to false temporarily to allow production deployment  

### DIFF
--- a/app/repositories/LookupRepository.scala
+++ b/app/repositories/LookupRepository.scala
@@ -52,10 +52,10 @@ class LookupRepositoryImpl @Inject() (mongo: MongoComponent, timeProvider: TimeP
       mongoComponent = mongo,
       domainFormat = MtdIdCached.encryptedFormat,
       indexes = Seq(
-        IndexModel(ascending("ninoHash"), IndexOptions().name("ninoHashIndex").unique(true).background(true)),
+        IndexModel(ascending("ninoHash"), IndexOptions().name("ninoHashIndex").unique(false).background(true)),
         IndexModel(ascending("lastUpdated"), IndexOptions().name("ttl").expireAfter(appConfig.ttl.toMinutes, MINUTES))
       ),
-      replaceIndexes = false
+      replaceIndexes = true
     )
     with LookupRepository {
 


### PR DESCRIPTION
Existing docs don't have ninoHash yet i.e. has null so returns the duplicate key exception on index creation. Will revert once I have deployed. Mongo is disabled in production so just a quick way to deploy so the dropping of the collection can be triggered [here](https://github.com/hmrc/mtd-identifier-lookup/blob/main/app/services/LookupService.scala#L58) which drops the collection that includes the index anyway.